### PR TITLE
Adding Manablade To Banlist

### DIFF
--- a/Zen Den Amends/amend_spells.xml
+++ b/Zen Den Amends/amend_spells.xml
@@ -19,12 +19,16 @@
 -->
 <chummer>
 	<spells>
-	<spell>
-      <name>Shape [Material]</name>
-      <bonus amendoperation="replace">
-        <selecttext xml="strings.xml" xpath="/chummer/materials/material" />
-      </bonus>
-    </spell>
+		<spell>
+			<name>Manablade</name>
+			<hide />
+		</spell>
+		<spell>
+			<name>Shape [Material]</name>
+			<bonus amendoperation="replace">
+				<selecttext xml="strings.xml" xpath="/chummer/materials/material" />
+			</bonus>
+		</spell>
 		<spell>
 			<name>Convert Blood to Ichor</name>
 			<hide />


### PR DESCRIPTION
Manablade wasn't showing up on the banned spell list. 

Resolves #15 