### PR TITLE
Regeneration Prereq Fix

### DIFF
--- a/Zen Den Amends/amend_qualities.xml
+++ b/Zen Den Amends/amend_qualities.xml
@@ -2377,7 +2377,7 @@
 		<quality>
 			<!-- Infected Optional Power: Regeneration -->
 			<name>Infected Optional Power: Regeneration</name>
-			<required amendoperation="addnode">
+			<required amendoperation="Replace">
 				<allof>
 					<quality>Infected Optional Power: Lesser Regeneration</quality>
 				</allof>

--- a/Zen Den Amends/custom_infected_qualities.xml
+++ b/Zen Den Amends/custom_infected_qualities.xml
@@ -288,10 +288,8 @@
 					<quality>Infected: Goblin</quality>
 					<quality>Infected: Mutaqua</quality>
 					<quality>Infected: Nosferatu</quality>
-					<quality>Infected: Vampire (Human)</quality>
-					<quality>Infected: Vampire (Non-Human)</quality>
-					<quality>Infected: Sukuyan (Human)</quality>
-					<quality>Infected: Sukuyan (Non-Human)</quality>
+					<quality>Infected: Vampire</quality>
+					<quality>Infected: Sukuyan</quality>
 					<quality>Infected: Wendigo</quality>
 				</oneof>
 			</required>


### PR DESCRIPTION
Fixes Regeneration's prerequisites so vampires and sukuyan can take it.