### PR TITLE
Lockdown gear

### DIFF
--- a/Zen Den Amends/amend_cyberdecks_gear.xml
+++ b/Zen Den Amends/amend_cyberdecks_gear.xml
@@ -195,6 +195,10 @@
       <name>Crystal Leviathan Shatterstar</name>
       <cost>200000</cost>
     </gear>
+    <gear>
+      <name>Transys Graygul</name>
+      <cost>315898</cost>
+    </gear>
     <!--<gear>
       <name>Allegiance Sigma</name>
       <cost>49500</cost>

--- a/Zen Den Amends/amend_weapons.xml
+++ b/Zen Den Amends/amend_weapons.xml
@@ -642,5 +642,24 @@
 			<name>Narcoject PEP</name>
 			<ammo>2x10(c) + energy</ammo>
 		</weapon>
+		<weapon>
+			<name>Repeating Laser</name>
+			<useskill>Directed Energy Weapons</useskill>
+			<damage>9P</damage>
+			<cost>35000</cost>
+		</weapon>
+		<weapon>
+			<name>Microwave Gun, High Frequency</name>
+			<useskill>Directed Energy Weapons</useskill>
+			<damage>8P</damage>
+			<ap>-half</ap>
+			<cost>50000</cost>
+		</weapon>
+		<weapon>
+			<name>Microwave Gun, Low Frequency</name>
+			<useskill>Directed Energy Weapons</useskill>
+			<damage>Special</damage>
+			<cost>50000</cost>
+		</weapon>
 	</weapons>
 </chummer>

--- a/Zen Den Amends/custom_gear.xml
+++ b/Zen Den Amends/custom_gear.xml
@@ -694,5 +694,14 @@
 			<cost>Rating * 2000</cost>
 			<allowrename>True</allowrename>
 		</gear>
+		<gear>
+			<id>91c14f4d-426d-4107-8d75-ba3e614cbe27</id>
+			<name>Magnetic Deflection Array</name>
+			<category>Survival Gear</category>
+			<source>LCD</source>
+			<page>208</page>
+			<avail>30F</avail>
+			<cost>100000</cost>
+		</gear>
 	</gears>
 </chummer>


### PR DESCRIPTION
Implemented Lockdown Gear:
* Repeating Laser has gotten the Laser buff, uses the DEW skill (in anticipation of the exotic weapons chanages), price was changed.
* Microwave Gun has gotten the changed price and uses DEW skill.
* Transys Graygul has had its price reduced by the cyberdeck cost break.
* MADAR was added as custom gear, under Survival Equipment (survival against bullets is survival).
* The Crazy-Repeller isn't in Chummer so no changes there were needed.

Resolves #174 
Resolves #176 
Resolves #177 
Resolves #178 
Resolves #179 