### PR TITLE
Restoring accidentally reverted changes

### DIFF
--- a/Zen Den Amends/custom_qualities.xml
+++ b/Zen Den Amends/custom_qualities.xml
@@ -1074,9 +1074,9 @@
 			<page>1</page>
 		</quality>
 		<quality>
-			<!-- Ware Overdriver -->
+			<!-- 'Ware Overdriver -->
 			<id>7050aca7-9882-4913-aba8-2e8da6b1c4b0</id>
-			<name>Ware Overdriver</name>
+			<name>'Ware Overdriver</name>
 			<karma>10</karma>
 			<category>Positive</category>
 			<bonus />
@@ -1444,6 +1444,14 @@
 			</bonus>
 			<source>ZDR</source>
 			<page>1</page>
+		</quality>
+		<quality>
+			<id>2ef8c275-dab8-47f7-b67a-e7f1de7be193</id>
+			<name>Lightning Strikes</name>
+			<karma>20</karma>
+			<category>Positive</category>
+			<doublecareer>False</doublecareer>
+			<bonus />
 		</quality>
 		<quality>
 			<id>c7db2317-bd32-4e9a-9f76-a26c7b8e87c6</id>

--- a/Zen Den Amends/custom_qualities.xml
+++ b/Zen Den Amends/custom_qualities.xml
@@ -1452,6 +1452,8 @@
 			<category>Positive</category>
 			<doublecareer>False</doublecareer>
 			<bonus />
+			<source>ZDR</source>
+			<page>1</page>
 		</quality>
 		<quality>
 			<id>c7db2317-bd32-4e9a-9f76-a26c7b8e87c6</id>

--- a/Zen Den Amends/manifest.xml
+++ b/Zen Den Amends/manifest.xml
@@ -19,7 +19,7 @@
 -->
 <manifest xmlns="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema ../manifest.xsd">
   <guid>6bcce4e0-6ae0-4c7d-b6c8-912606db090d</guid>
-  <version>11.1</version>
+  <version>11.2</version>
   <authors>
     <author>
       <name>Zen Den Gurus</name>


### PR DESCRIPTION
This re-adds Lightning Strikes and fixes Ware Overdriver which were accidentally reverted in #208 because I'm a big dumb dumb