### PR TITLE
Fix Improved Reactions not giving bonus REA

### DIFF
--- a/Zen Den Amends/amend_powers.xml
+++ b/Zen Den Amends/amend_powers.xml
@@ -24,6 +24,10 @@
 			<bonus amendoperation="replace">
 				<disablequality amendoperation="remove">3564b678-7721-4a8d-ac79-1600cf92dc14</disablequality>
 				<initiativepass amendoperation="replace">Rating</initiativepass>
+				<specificattribute amendoperation="replace">
+          			<name>REA</name>
+          			<val>Rating</val>
+        			</specificattribute>
 			</bonus>
 		</power>
 		<power>


### PR DESCRIPTION
It seems that the amend to remove the suppression of lighting reflexes also removed the REA bonus. This has been fixed.