### PR TITLE
Skill Group Reflex Recorders include Vehicle Skills

### DIFF
--- a/Zen Den Amends/custom_bioware.xml
+++ b/Zen Den Amends/custom_bioware.xml
@@ -797,12 +797,12 @@
 				<grade>Used</grade>
 				<grade>Used (Adapsin)</grade>
 			</bannedgrades>
-			<ess>0.2</ess>
+			<ess>0.1</ess>
 			<capacity>0</capacity>
 			<avail>12</avail>
 			<cost>35000</cost>
 			<bonus>
-				<selectskillgroup excludecategory="Magical Active,Resonance Active,Social Active,Technical Active,Vechicle Active">
+				<selectskillgroup excludecategory="Magical Active,Resonance Active,Social Active,Technical Active">
 					<bonus>1</bonus>
 				</selectskillgroup>
 			</bonus>

--- a/Zen Den Amends/custom_bioware.xml
+++ b/Zen Den Amends/custom_bioware.xml
@@ -797,7 +797,7 @@
 				<grade>Used</grade>
 				<grade>Used (Adapsin)</grade>
 			</bannedgrades>
-			<ess>0.1</ess>
+			<ess>0.2</ess>
 			<capacity>0</capacity>
 			<avail>12</avail>
 			<cost>35000</cost>


### PR DESCRIPTION
This should allow skill group reflex recorders to give bonuses to vehicle skills, and also reduces their essence cost back to 0.1 because nobody has noticed that they weren't properly implemented for over a month, suggesting pretty low demand at their current cost.