### PR TITLE
Stimtouch Hosiery Uses Unarmed

### DIFF
--- a/Zen Den Amends/amend_weapons.xml
+++ b/Zen Den Amends/amend_weapons.xml
@@ -610,6 +610,10 @@
 			<name>Functional Tail (Thagomizer)</name>
 			<useskill>Unarmed Combat</useskill>
 		</weapon>
+		<weapon>
+			<name>Stimtouch Hosiery</name>
+			<category>Unarmed</category>
+		</weapon>
 		<!--  END EXOTIC WEAPON SKILLS -->
 		<!--Banned Items-->
 		<weapon>
@@ -663,3 +667,4 @@
 		</weapon>
 	</weapons>
 </chummer>
+


### PR DESCRIPTION
Everyone forgets about this, probably because few people ever take it, but it's not even listed as an exotic weapon in the first place.

Anyways, it's now Unarmed, because we've depreciated most exotic weapons skills.