### PR TITLE
Enable German books and change lift/carry calculations

### DIFF
--- a/Zen Den Karmagen.xml
+++ b/Zen Den Karmagen.xml
@@ -20,8 +20,8 @@
 	<boundspiritexpression>{CHA}</boundspiritexpression>
 	<registeredspriteexpression>{LOG}</registeredspriteexpression>
 	<essencemodifierpostexpression>{Modifier}</essencemodifierpostexpression>
-	<liftlimitexpression>{STR} * 15</liftlimitexpression>
-	<carrylimitexpression>{STR} * 10</carrylimitexpression>
+	<liftlimitexpression>{STR} * {STR} * 10</liftlimitexpression>
+	<carrylimitexpression>{STR} * {STR} * 5</carrylimitexpression>
 	<encumbranceintervalexpression>15</encumbranceintervalexpression>
 	<doencumbrancepenaltyphysicallimit>True</doencumbrancepenaltyphysicallimit>
 	<doencumbrancepenaltymovementspeed>False</doencumbrancepenaltymovementspeed>
@@ -180,6 +180,7 @@
 		<book>CA</book>
 		<book>BOTL</book>
 		<book>FA</book>
+		<book>SAG</book>
 		<book>TCT</book>
 		<book>SFCC</book>
 		<book>DTR</book>
@@ -189,6 +190,7 @@
 		<book>BTB</book>
 		<book>AET</book>
 		<book>NF</book>
+		<book>SOTG</book>
 		<book>KK</book>
 		<book>SW</book>
 		<book>4e</book>

--- a/Zen Den STE.xml
+++ b/Zen Den STE.xml
@@ -20,8 +20,8 @@
 	<boundspiritexpression>{CHA}</boundspiritexpression>
 	<registeredspriteexpression>{LOG}</registeredspriteexpression>
 	<essencemodifierpostexpression>{Modifier}</essencemodifierpostexpression>
-	<liftlimitexpression>{STR} * 15</liftlimitexpression>
-	<carrylimitexpression>{STR} * 10</carrylimitexpression>
+	<liftlimitexpression>{STR} * {STR} * 10</liftlimitexpression>
+	<carrylimitexpression>{STR} * {STR} * 5</carrylimitexpression>
 	<encumbranceintervalexpression>15</encumbranceintervalexpression>
 	<doencumbrancepenaltyphysicallimit>True</doencumbrancepenaltyphysicallimit>
 	<doencumbrancepenaltymovementspeed>False</doencumbrancepenaltymovementspeed>
@@ -180,6 +180,7 @@
 		<book>CA</book>
 		<book>BOTL</book>
 		<book>FA</book>
+		<book>SAG</book>
 		<book>TCT</book>
 		<book>SFCC</book>
 		<book>DTR</book>
@@ -189,6 +190,7 @@
 		<book>BTB</book>
 		<book>AET</book>
 		<book>NF</book>
+		<book>SOTG</book>
 		<book>KK</book>
 		<book>SW</book>
 		<book>4e</book>


### PR DESCRIPTION
This enables SOTA 2080 and ADL content and also alters the lifting and carrying equations to comport with 6e.